### PR TITLE
Add problem fuzzing command and allow for multiple files to be compared

### DIFF
--- a/crates/cli/src/cli/problem.rs
+++ b/crates/cli/src/cli/problem.rs
@@ -5,12 +5,9 @@ use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 
 use crate::config::Settings;
 use crate::problem::fuzz;
-use crate::problem::{
-    archive, check, compare, create, generate,
-    run::{RunnableCategory, RunnableFile},
-    solve, test,
-};
-use crate::util::{get_lang_from_extension, get_problem_from_cwd, get_project_root};
+use crate::problem::run::{RunnableCategory, RunnableFile};
+use crate::problem::{archive, check, compare, create, generate, solve, test};
+use crate::util::{get_problem_from_cwd, get_project_root};
 
 pub fn cli() -> Command {
     Command::new("problem")
@@ -44,7 +41,7 @@ pub fn cli() -> Command {
                     Arg::new("file")
                         .long("file")
                         .help("Name of the solution file")
-                        .action(ArgAction::Set),
+                        .action(ArgAction::Append),
                     Arg::new("problem")
                         .short('p')
                         .long("problem")
@@ -77,14 +74,10 @@ pub fn cli() -> Command {
                     Arg::new("file")
                         .long("file")
                         .help("Name of the solution file")
-                        .action(ArgAction::Set),
+                        .action(ArgAction::Append),
                     Arg::new("generator-file")
                         .long("generator-file")
                         .help("Name of the generator file")
-                        .action(ArgAction::Set),
-                    Arg::new("generator-lang")
-                        .long("generator-lang")
-                        .help("Language of the generator file (e.g. cpp, py)")
                         .action(ArgAction::Set),
                     Arg::new("problem")
                         .short('p')
@@ -100,10 +93,6 @@ pub fn cli() -> Command {
                     Arg::new("file")
                         .long("file")
                         .help("Name of the generator file")
-                        .action(ArgAction::Set),
-                    Arg::new("lang")
-                        .long("lang")
-                        .help("Language of the generator file (e.g. cpp, py)")
                         .action(ArgAction::Set),
                     Arg::new("problem")
                         .short('p')
@@ -199,13 +188,9 @@ pub fn exec(args: &ArgMatches, settings: &Settings) -> Result<()> {
 
             let mut solution_files: Vec<RunnableFile> = Vec::new();
             for f in files {
-                let solution_file = RunnableFile::new(
-                    settings,
-                    RunnableCategory::Solution,
-                    Some(f),
-                    Some(&get_lang_from_extension(f)?),
-                );
-                solution_files.push(solution_file);
+                let solution_file =
+                    RunnableFile::new(settings, RunnableCategory::Solution, Some(f));
+                solution_files.push(solution_file?);
             }
 
             let compare_args = compare::CompareArgs {
@@ -244,21 +229,16 @@ pub fn exec(args: &ArgMatches, settings: &Settings) -> Result<()> {
 
             let mut solution_files: Vec<RunnableFile> = Vec::new();
             for f in files {
-                let solution_file = RunnableFile::new(
-                    settings,
-                    RunnableCategory::Solution,
-                    Some(f),
-                    Some(&get_lang_from_extension(f)?),
-                );
-                solution_files.push(solution_file);
+                let solution_file =
+                    RunnableFile::new(settings, RunnableCategory::Solution, Some(f));
+                solution_files.push(solution_file?);
             }
 
             let generator = RunnableFile::new(
                 settings,
                 RunnableCategory::Generator,
                 cmd.try_get_one::<String>("generator-file")?,
-                cmd.try_get_one::<String>("generator-lang")?,
-            );
+            )?;
 
             let fuzz_args = fuzz::FuzzArgs {
                 problems_dir: &problems_dir,
@@ -279,8 +259,7 @@ pub fn exec(args: &ArgMatches, settings: &Settings) -> Result<()> {
                 settings,
                 RunnableCategory::Generator,
                 cmd.try_get_one::<String>("file")?,
-                cmd.try_get_one::<String>("lang")?,
-            );
+            )?;
 
             let test_name = cmd
                 .try_get_one::<String>("test-name")?

--- a/crates/cli/src/problem/compare.rs
+++ b/crates/cli/src/problem/compare.rs
@@ -69,7 +69,7 @@ pub fn compare(settings: &Settings, compare_args: &CompareArgs) -> Result<()> {
             // TODO: compare 1st, 2nd and nth result for a "best of three" (if applicable)?
             if result_1.output.as_bytes() != result.output.as_bytes() {
                 eprintln!(
-                        "  ! Test case failed: {test_file}, solution 1 took {:.5}s, solution {i} took {:.5}s",
+                        "  ! Test case failed: {test_file}, solution 0 took {:.5}s, solution {i} took {:.5}s",
                         result_1.elapsed_time.as_secs_f64(),
                         result.elapsed_time.as_secs_f64()
                     );

--- a/crates/cli/src/problem/fuzz.rs
+++ b/crates/cli/src/problem/fuzz.rs
@@ -1,29 +1,31 @@
+use std::fs;
 use std::path::Path;
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
+use uuid::Uuid;
 
-use super::run::{RunCommand, RunnableFile};
+use super::generate;
+use super::run::{RunCommand, RunResult, RunnableFile};
 use super::sync_mappings::get_problem;
-use crate::config::Settings;
-use crate::problem::run::RunResult;
-use crate::util::{get_input_files_in_directory, get_project_root};
+use crate::{config::Settings, util::get_project_root};
 
-/// Arguments for the compare command.
-pub struct CompareArgs<'a> {
+pub struct FuzzArgs<'a> {
     pub problems_dir: &'a Path,
     pub problem_name: String,
     pub solution_files: Vec<RunnableFile>,
+    pub generator: RunnableFile,
 }
 
-/// Compare two solutions.
-pub fn compare(settings: &Settings, compare_args: &CompareArgs) -> Result<()> {
+/// Generate new test cases until the solutions produce different results.
+pub fn fuzz(settings: &Settings, fuzz_args: &FuzzArgs) -> Result<()> {
     let project_root = get_project_root()?;
-    let CompareArgs {
+    let FuzzArgs {
         problems_dir,
         problem_name,
         solution_files,
-    } = compare_args;
+        generator,
+    } = fuzz_args;
     let problem_path = project_root.join(get_problem(problems_dir, problem_name)?);
 
     let mut run_commands: Vec<RunCommand> = Vec::new();
@@ -39,19 +41,22 @@ pub fn compare(settings: &Settings, compare_args: &CompareArgs) -> Result<()> {
 
     // If there aren't at least two solutions, we can't compare so return an error
     if run_commands.len() < 2 {
-        bail!("At least two solutions are required to compare.");
+        bail!("At least two solutions are required for fuzzing.");
     }
 
-    let test_files = get_input_files_in_directory(problem_path.join("tests"))?;
-
-    let mut tests_passed = 0;
     let mut total_tests = 0;
     let mut total_times: Vec<Duration> = vec![Duration::new(0, 0); run_commands.len()];
 
-    eprintln!("Running the solution files for each test case...");
+    // TODO: Set an optional limit?
+    loop {
+        total_tests += 1;
 
-    for test_file in test_files {
-        let input_file_path = problem_path.join(format!("tests/{}", test_file));
+        let test_name = format!("generated_{}", Uuid::new_v4());
+
+        generate::generate(settings, problems_dir, problem_name, generator, &test_name)
+            .context("Failed to generate test case")?;
+
+        let input_file_path = problem_path.join(format!("tests/{}.in", test_name));
 
         let mut results: Vec<RunResult> = Vec::new();
         for (i, run_cmd) in run_commands.iter().enumerate() {
@@ -69,7 +74,7 @@ pub fn compare(settings: &Settings, compare_args: &CompareArgs) -> Result<()> {
             // TODO: compare 1st, 2nd and nth result for a "best of three" (if applicable)?
             if result_1.output.as_bytes() != result.output.as_bytes() {
                 eprintln!(
-                        "  ! Test case failed: {test_file}, solution 1 took {:.5}s, solution {i} took {:.5}s",
+                        "  ! Test case {total_tests} (tests/generated.in) failed, solution 1 took {:.5}s, solution {i} took {:.5}s",
                         result_1.elapsed_time.as_secs_f64(),
                         result.elapsed_time.as_secs_f64()
                     );
@@ -80,22 +85,35 @@ pub fn compare(settings: &Settings, compare_args: &CompareArgs) -> Result<()> {
         }
 
         if passed {
+            let max_total_time = total_times
+                .iter()
+                .max()
+                .unwrap_or(&Duration::new(0, 0))
+                .to_owned();
+            let min_total_time = total_times
+                .iter()
+                .min()
+                .unwrap_or(&Duration::new(0, 0))
+                .to_owned();
+
             eprintln!(
-                "  + Test case passed: {test_file}, average time taken: {:.5}s",
+                "  + Test case {total_tests} passed, average time taken: {:.5}s",
                 avg_duration.as_secs_f64() / (results.len() as f64)
             );
-            tests_passed += 1;
+            eprintln!(
+                "    Total percentage time difference (min, max times): {:.5}%",
+                (max_total_time.abs_diff(min_total_time)).as_secs_f64() * 100f64
+                    / min_total_time.as_secs_f64()
+            );
+
+            fs::remove_file(input_file_path).context("Failed to delete generated test case")?;
+        } else {
+            break;
         }
 
-        total_tests += 1;
         for (i, result) in results.iter().enumerate() {
             total_times[i] += result.elapsed_time;
         }
-    }
-
-    eprintln!("{tests_passed} out of {total_tests} test cases passed");
-    for (i, time) in total_times.iter().enumerate() {
-        eprintln!(" Time taken for solution {i}: {:.5}s", time.as_secs_f64());
     }
 
     for run_command in run_commands {

--- a/crates/cli/src/problem/fuzz.rs
+++ b/crates/cli/src/problem/fuzz.rs
@@ -74,7 +74,7 @@ pub fn fuzz(settings: &Settings, fuzz_args: &FuzzArgs) -> Result<()> {
             // TODO: compare 1st, 2nd and nth result for a "best of three" (if applicable)?
             if result_1.output.as_bytes() != result.output.as_bytes() {
                 eprintln!(
-                        "  ! Test case {total_tests} (tests/generated.in) failed, solution 1 took {:.5}s, solution {i} took {:.5}s",
+                        "  ! Test case {total_tests} (tests/generated.in) failed, solution 0 took {:.5}s, solution {i} took {:.5}s",
                         result_1.elapsed_time.as_secs_f64(),
                         result.elapsed_time.as_secs_f64()
                     );

--- a/crates/cli/src/problem/mod.rs
+++ b/crates/cli/src/problem/mod.rs
@@ -4,6 +4,7 @@ pub mod archive;
 pub mod check;
 pub mod compare;
 pub mod create;
+pub mod fuzz;
 pub mod generate;
 pub mod run;
 pub mod solve;

--- a/crates/cli/src/problem/run.rs
+++ b/crates/cli/src/problem/run.rs
@@ -62,6 +62,9 @@ impl fmt::Display for RunnableFile {
 }
 
 /// Represents a command to run a solution or generator file.
+// TODO: Technically it wouldn't really be correct to have a "script_file"
+// if the file is only compiled, so we should probably make bin_file and
+// script_file mutually exclusive
 pub struct RunCommand {
     bin_file: PathBuf,
     script_file: PathBuf,

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -67,3 +67,13 @@ pub fn is_file_empty<P: AsRef<Path>>(path: P) -> Result<bool> {
     let metadata = fs::metadata(path)?;
     Ok(metadata.len() == 0)
 }
+
+pub fn get_lang_from_extension<P: AsRef<Path>>(path: P) -> Result<String> {
+    let lang = path
+        .as_ref()
+        .extension()
+        .and_then(|s| s.to_str())
+        .context("Failed to get file extension")?
+        .to_string();
+    Ok(lang)
+}

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -21,7 +21,11 @@ pub fn get_project_root() -> Result<PathBuf> {
 /// Get the name of the problem from the current working directory if the
 /// directory is a valid problem folder.
 pub fn get_problem_from_cwd(problems_dir: &Path) -> Result<String> {
+    let project_root = get_project_root()?;
     let path = std::env::current_dir()?;
+    if project_root == path {
+        bail!("You are in the project root directory. Please navigate to a problem directory");
+    }
     let problem_name = path
         .file_name()
         .context("Failed to get problem name")?


### PR DESCRIPTION
- Add a dedicated `problem fuzz` command
- Allow for multiple files to be compared for `problem compare` and `problem fuzz` (instead of just 2)
- The language is now automatically inferred from the file extension

Resolves #3 