### PR TITLE
feat: custom-checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Problems are stored in a `problems` folder. This can be changed in the `settings
 
 Within each difficulty folder, there are the individual problems. Each of these folders will contain a `problem.md` which is the problem statement. There will be a `tests` folder for test cases and a `solutions` folder for reference solutions.
 
+If a problem folder contains a `checker.py` next to `problem.md`, `aucpl problem test` will use it as a custom checker. The file must define `check(process_output, judge_output, **kwargs)` and return a boolean.
+
 Lastly, there is a `problem-mappings.json` file that maps the problem names to its stored location. This is so that in the CLI, you do not have to specify things like the rating or whether it's a new or archived problem. You can also use `aucpl sync` to generate or update the mappings.
 
 The general structure of `problems` looks like this:
@@ -49,6 +51,7 @@ problems/
         0800/
             problem-foo/
                 problem.md
+                checker.py
                 solutions/
                     solution.cpp
                     solution.py
@@ -76,7 +79,7 @@ Problems
 
 - `aucpl problem create`: Create a new problem and generate necessary files
 - `aucpl problem solve`: Automatically generate output test cases for a given problem
-- `aucpl problem test`: Automatically run all tests for a given problem
+- `aucpl problem test`: Automatically run all tests for a given problem (uses `checker.py` if present, otherwise exact output match)
 - `aucpl problem check`: Ensure test cases and files are not missing
 - `aucpl problem generate`: Generate test case inputs with generator files
 - `aucpl problem compare`: Compare two or more solutions and their outputs

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Problems are stored in a `problems` folder. This can be changed in the `settings
 
 Within each difficulty folder, there are the individual problems. Each of these folders will contain a `problem.md` which is the problem statement. There will be a `tests` folder for test cases and a `solutions` folder for reference solutions.
 
-If a problem folder contains a `checker.py` next to `problem.md`, `aucpl problem test` will use it as a custom checker. The file must define `check(process_output, judge_output, **kwargs)` and return a boolean.
+If a problem folder contains a `checker.py` next to `problem.md`, `aucpl problem test` will use it as a custom checker. The file must define `check(process_output, judge_output)` and return a boolean.
 
 Lastly, there is a `problem-mappings.json` file that maps the problem names to its stored location. This is so that in the CLI, you do not have to specify things like the rating or whether it's a new or archived problem. You can also use `aucpl sync` to generate or update the mappings.
 

--- a/crates/cli/src/problem/run.rs
+++ b/crates/cli/src/problem/run.rs
@@ -201,6 +201,26 @@ impl RunCommand {
         })
     }
 
+    /// Creates a `RunCommand` directly from an explicit command vector.
+    ///
+    /// This is useful for ad-hoc command execution where language settings and
+    /// compilation are not needed.
+    pub fn from_command(
+        bin_file: PathBuf,
+        script_file: PathBuf,
+        run_command: Vec<String>,
+    ) -> Result<Self> {
+        if run_command.is_empty() {
+            bail!("No run command specified. It must be specified!");
+        }
+
+        Ok(Self {
+            bin_file,
+            script_file,
+            run_command,
+        })
+    }
+
     /// Returns the result of running the command, capturing its output and elapsed time.
     /// If `input_file_path` is provided, it will be used as the standard input for the command.
     pub fn get_result(&self, input_file_path: Option<&PathBuf>) -> Result<RunResult> {

--- a/crates/cli/src/problem/run.rs
+++ b/crates/cli/src/problem/run.rs
@@ -11,6 +11,29 @@ use subprocess::{Exec, Redirection};
 use crate::config::Settings;
 use crate::util::get_lang_from_extension;
 
+/// Get the Python executable from the `py` language settings, falling back to
+/// platform-appropriate defaults (`py` on Windows, `python3` elsewhere).
+pub fn get_python_executable(settings: &Settings) -> String {
+    if let Some(py_settings) = settings.problem.solution.get("py") {
+        if let Some(run_cmd) = &py_settings.run_command {
+            if let Some(cmd) = run_cmd.first() {
+                // Skip placeholder tokens used for file substitution in run commands
+                if cmd != "@script_file" && cmd != "@bin_file" {
+                    return cmd.clone();
+                }
+            }
+        }
+    }
+    #[cfg(windows)]
+    {
+        "py".to_string()
+    }
+    #[cfg(not(windows))]
+    {
+        "python3".to_string()
+    }
+}
+
 /// Represents the category of a runnable file, either a solution or a generator.
 #[derive(Eq, PartialEq)]
 pub enum RunnableCategory {

--- a/crates/cli/src/problem/test.rs
+++ b/crates/cli/src/problem/test.rs
@@ -1,13 +1,13 @@
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
-use std::process::{Command, Stdio};
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
+use subprocess::{Exec, Redirection};
 
 use crate::config::Settings;
-use crate::problem::run::{RunCommand, RunnableFile};
+use crate::problem::run::{get_python_executable, RunCommand, RunnableFile};
 use crate::util::{get_input_files_in_directory, get_project_root};
 
 use super::sync_mappings::get_problem;
@@ -38,40 +38,38 @@ print("true" if bool(result) else "false")
 "#;
 
 fn run_custom_checker(
+    settings: &Settings,
     checker_path: &Path,
     process_output: &str,
     judge_output: &[u8],
 ) -> Result<bool> {
     let judge_output = String::from_utf8_lossy(judge_output).into_owned();
+    let python_cmd = get_python_executable(settings);
 
-    let checker_process = Command::new("python3")
+    let result = Exec::cmd(&python_cmd)
         .arg("-c")
         .arg(PYTHON_CHECKER_SCRIPT)
         .arg(checker_path)
         .arg(process_output)
         .arg(&judge_output)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .context("Failed to run checker.py with python3")?;
+        .stdout(Redirection::Pipe)
+        .stderr(Redirection::Pipe)
+        .capture()
+        .context("Failed to run checker.py")?;
 
-    let output = checker_process
-        .wait_with_output()
-        .context("Failed to wait for checker.py execution")?;
-
-    if !output.status.success() {
-        anyhow::bail!(
+    if !result.success() {
+        bail!(
             "checker.py failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            result.stderr_str().trim()
         );
     }
 
-    let checker_result = String::from_utf8_lossy(&output.stdout);
+    let checker_result = result.stdout_str();
     let passed = match checker_result.trim().to_ascii_lowercase().as_str() {
         "true" => true,
         "false" => false,
         other => {
-            anyhow::bail!(
+            bail!(
                 "checker.py must return a bool-compatible result, got: {}",
                 other
             )
@@ -132,7 +130,7 @@ pub fn test(
         output_file.read_to_end(expected)?;
 
         let passed = if use_custom_checker {
-            run_custom_checker(&checker_path, &out_str, expected)?
+            run_custom_checker(settings, &checker_path, &out_str, expected)?
         } else {
             expected == out_str.as_bytes()
         };

--- a/crates/cli/src/problem/test.rs
+++ b/crates/cli/src/problem/test.rs
@@ -1,10 +1,10 @@
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
-use subprocess::{Exec, Redirection};
 
 use crate::config::Settings;
 use crate::problem::run::{get_python_executable, RunCommand, RunnableFile};
@@ -46,25 +46,25 @@ fn run_custom_checker(
     let judge_output = String::from_utf8_lossy(judge_output).into_owned();
     let python_cmd = get_python_executable(settings);
 
-    let result = Exec::cmd(&python_cmd)
-        .arg("-c")
-        .arg(PYTHON_CHECKER_SCRIPT)
-        .arg(checker_path)
-        .arg(process_output)
-        .arg(&judge_output)
-        .stdout(Redirection::Pipe)
-        .stderr(Redirection::Pipe)
-        .capture()
-        .context("Failed to run checker.py")?;
+    let checker_run = RunCommand::from_command(
+        PathBuf::new(),
+        checker_path.to_path_buf(),
+        vec![
+            python_cmd,
+            "-c".to_string(),
+            PYTHON_CHECKER_SCRIPT.to_string(),
+            "@script_file".to_string(),
+            process_output.to_string(),
+            judge_output,
+        ],
+    )
+    .context("Failed to prepare checker command")?;
 
-    if !result.success() {
-        bail!(
-            "checker.py failed: {}",
-            result.stderr_str().trim()
-        );
-    }
+    let checker_result = checker_run
+        .get_result(None)
+        .context("Failed to run checker.py")?
+        .output;
 
-    let checker_result = result.stdout_str();
     let passed = match checker_result.trim().to_ascii_lowercase().as_str() {
         "true" => true,
         "false" => false,

--- a/crates/cli/src/problem/test.rs
+++ b/crates/cli/src/problem/test.rs
@@ -1,15 +1,112 @@
 use std::fs::File;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::Path;
+use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use serde_json::json;
 
 use crate::config::Settings;
 use crate::problem::run::{RunCommand, RunnableFile};
 use crate::util::{get_input_files_in_directory, get_project_root};
 
 use super::sync_mappings::get_problem;
+
+const PYTHON_CHECKER_SCRIPT: &str = r#"
+import importlib.util
+import json
+import sys
+
+
+def parse_value(value):
+    stripped = value.strip()
+    if stripped == "":
+        return ""
+
+    try:
+        return json.loads(stripped)
+    except Exception:
+        return stripped
+
+
+def main():
+    payload = json.load(sys.stdin)
+
+    spec = importlib.util.spec_from_file_location("aucpl_checker", payload["checker_path"])
+    if spec is None or spec.loader is None:
+        print("Could not load checker.py", file=sys.stderr)
+        sys.exit(2)
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    if not hasattr(module, "check"):
+        print("checker.py must define a `check` function", file=sys.stderr)
+        sys.exit(2)
+
+    result = module.check(
+        parse_value(payload["process_output"]),
+        parse_value(payload["judge_output"]),
+        process_output_raw=payload["process_output"],
+        judge_output_raw=payload["judge_output"],
+        test_file=payload["test_file"],
+    )
+
+    print(json.dumps(bool(result)))
+
+
+if __name__ == "__main__":
+    main()
+"#;
+
+fn run_custom_checker(
+    checker_path: &Path,
+    process_output: &str,
+    judge_output: &[u8],
+    test_file: &str,
+) -> Result<bool> {
+    let payload = json!({
+        "checker_path": checker_path,
+        "process_output": process_output,
+        "judge_output": String::from_utf8_lossy(judge_output),
+        "test_file": test_file,
+    });
+
+    let mut checker_process = Command::new("python3")
+        .arg("-c")
+        .arg(PYTHON_CHECKER_SCRIPT)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("Failed to run checker.py with python3")?;
+
+    if let Some(stdin) = checker_process.stdin.as_mut() {
+        stdin
+            .write_all(payload.to_string().as_bytes())
+            .context("Failed to send checker payload to python process")?;
+    }
+
+    let output = checker_process
+        .wait_with_output()
+        .context("Failed to wait for checker.py execution")?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "checker.py failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let checker_result = String::from_utf8_lossy(&output.stdout);
+    let passed = serde_json::from_str::<bool>(checker_result.trim()).context(format!(
+        "checker.py must return a bool-compatible result, got: {}",
+        checker_result.trim()
+    ))?;
+
+    Ok(passed)
+}
 
 /// Automatically run tests on the problem.
 pub fn test(
@@ -30,8 +127,13 @@ pub fn test(
     )?;
 
     let test_files = get_input_files_in_directory(problem_path.join("tests"))?;
+    let checker_path = problem_path.join("checker.py");
+    let use_custom_checker = checker_path.exists();
 
     eprintln!("Running the solution file for each test case...");
+    if use_custom_checker {
+        eprintln!("Using custom checker at: {}", checker_path.display());
+    }
 
     let mut tests_passed = 0;
     let mut total_tests = 0;
@@ -56,7 +158,13 @@ pub fn test(
         let expected: &mut Vec<u8> = &mut Vec::new();
         output_file.read_to_end(expected)?;
 
-        if expected != out_str.as_bytes() {
+        let passed = if use_custom_checker {
+            run_custom_checker(&checker_path, &out_str, expected, &test_file)?
+        } else {
+            expected == out_str.as_bytes()
+        };
+
+        if !passed {
             eprintln!(
                 "  ! Test case failed: {test_file}, time taken: {:.5}s",
                 elapsed_time.as_secs_f64()

--- a/crates/cli/src/problem/test.rs
+++ b/crates/cli/src/problem/test.rs
@@ -1,11 +1,10 @@
 use std::fs::File;
-use std::io::{Read, Write};
+use std::io::Read;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use serde_json::json;
 
 use crate::config::Settings;
 use crate::problem::run::{RunCommand, RunnableFile};
@@ -15,78 +14,46 @@ use super::sync_mappings::get_problem;
 
 const PYTHON_CHECKER_SCRIPT: &str = r#"
 import importlib.util
-import json
 import sys
 
+checker_path = sys.argv[1]
+process_output = sys.argv[2]
+judge_output = sys.argv[3]
 
-def parse_value(value):
-    stripped = value.strip()
-    if stripped == "":
-        return ""
+spec = importlib.util.spec_from_file_location("aucpl_checker", checker_path)
+if spec is None or spec.loader is None:
+    print("Could not load checker.py", file=sys.stderr)
+    sys.exit(2)
 
-    try:
-        return json.loads(stripped)
-    except Exception:
-        return stripped
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
 
+if not hasattr(module, "check"):
+    print("checker.py must define a `check` function", file=sys.stderr)
+    sys.exit(2)
 
-def main():
-    payload = json.load(sys.stdin)
+result = module.check(process_output, judge_output)
 
-    spec = importlib.util.spec_from_file_location("aucpl_checker", payload["checker_path"])
-    if spec is None or spec.loader is None:
-        print("Could not load checker.py", file=sys.stderr)
-        sys.exit(2)
-
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-
-    if not hasattr(module, "check"):
-        print("checker.py must define a `check` function", file=sys.stderr)
-        sys.exit(2)
-
-    result = module.check(
-        parse_value(payload["process_output"]),
-        parse_value(payload["judge_output"]),
-        process_output_raw=payload["process_output"],
-        judge_output_raw=payload["judge_output"],
-        test_file=payload["test_file"],
-    )
-
-    print(json.dumps(bool(result)))
-
-
-if __name__ == "__main__":
-    main()
+print("true" if bool(result) else "false")
 "#;
 
 fn run_custom_checker(
     checker_path: &Path,
     process_output: &str,
     judge_output: &[u8],
-    test_file: &str,
 ) -> Result<bool> {
-    let payload = json!({
-        "checker_path": checker_path,
-        "process_output": process_output,
-        "judge_output": String::from_utf8_lossy(judge_output),
-        "test_file": test_file,
-    });
+    let judge_output = String::from_utf8_lossy(judge_output).into_owned();
 
-    let mut checker_process = Command::new("python3")
+    let checker_process = Command::new("python3")
         .arg("-c")
         .arg(PYTHON_CHECKER_SCRIPT)
-        .stdin(Stdio::piped())
+        .arg(checker_path)
+        .arg(process_output)
+        .arg(&judge_output)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .context("Failed to run checker.py with python3")?;
-
-    if let Some(stdin) = checker_process.stdin.as_mut() {
-        stdin
-            .write_all(payload.to_string().as_bytes())
-            .context("Failed to send checker payload to python process")?;
-    }
 
     let output = checker_process
         .wait_with_output()
@@ -100,10 +67,16 @@ fn run_custom_checker(
     }
 
     let checker_result = String::from_utf8_lossy(&output.stdout);
-    let passed = serde_json::from_str::<bool>(checker_result.trim()).context(format!(
-        "checker.py must return a bool-compatible result, got: {}",
-        checker_result.trim()
-    ))?;
+    let passed = match checker_result.trim().to_ascii_lowercase().as_str() {
+        "true" => true,
+        "false" => false,
+        other => {
+            anyhow::bail!(
+                "checker.py must return a bool-compatible result, got: {}",
+                other
+            )
+        }
+    };
 
     Ok(passed)
 }
@@ -159,7 +132,7 @@ pub fn test(
         output_file.read_to_end(expected)?;
 
         let passed = if use_custom_checker {
-            run_custom_checker(&checker_path, &out_str, expected, &test_file)?
+            run_custom_checker(&checker_path, &out_str, expected)?
         } else {
             expected == out_str.as_bytes()
         };


### PR DESCRIPTION
Add custom checker python support for `aucpl problem test`. It will check for `checker.py` files next to `problem.md`, and execute them instead of just doing string comparison if they exist. Here is an example of a valid checker.py:

```py
def check(process_output, judge_output):
    return abs(float(process_output) - float(judge_output)) <= 0.5
```

Limitation: Often you will import dmoj things in the checkers, which doesn't work here. The functions can only be raw Python scripts. Also, you can only use the process output and judge output, although DMOJ passes in much more information to their custom judges. https://docs.dmoj.ca/#/problem_format/custom_checkers?id=custom-checkers-1