### PR TITLE
feat: CD command

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,20 @@ Competitions
 
 Other
 
+- `aucpl cd`: Print the path to a problem directory (or the workspace root when omitted)
 - `aucpl init`: Create a new project
 - `aucpl help`: Show help
 - `aucpl sync`: Generate or update the problem mappings file
+
+To make `aucpl cd` change your current shell directory, install the shell hook once per shell session:
+
+```sh
+eval "$(aucpl cd --shell-hook)"
+```
+
+Then you can run:
+
+```sh
+aucpl cd
+aucpl cd <problem-name>
+```

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Other
 To make `aucpl cd` change your current shell directory, install the shell hook once per shell session:
 
 ```sh
-eval "$(aucpl shellinit)"
+eval $(aucpl shellinit)
 ```
 
 Then you can run:

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Other
 To make `aucpl cd` change your current shell directory, install the shell hook once per shell session:
 
 ```sh
-eval "$(aucpl cd --shell-hook)"
+eval "$(aucpl shellinit)"
 ```
 
 Then you can run:

--- a/crates/cli/src/cli/cd.rs
+++ b/crates/cli/src/cli/cd.rs
@@ -10,13 +10,8 @@ use crate::util::get_project_root;
 
 pub fn cli() -> Command {
     Command::new("cd")
-        .about("Print the target directory for a problem or the workspace root")
-        .arg(
-            Arg::new("shell-hook")
-                .long("shell-hook")
-                .help("Print shell integration snippet so 'aucpl cd' changes your current shell directory")
-                .action(ArgAction::SetTrue),
-        )
+        .about("Print the target directory for a problem or the workspace root.
+Evaluate `aucpl shellinit` to instead cd to the directory.")
         .arg(
             Arg::new("problem")
                 .help("Problem name")
@@ -25,13 +20,6 @@ pub fn cli() -> Command {
 }
 
 pub fn exec(args: &ArgMatches) -> Result<()> {
-    if args.get_flag("shell-hook") {
-        println!(
-            "aucpl() {{\n  if [ \"$1\" = \"cd\" ]; then\n    shift\n    local target\n    target=\"$(command aucpl cd \"$@\")\" || return $?\n    builtin cd -- \"$target\"\n  else\n    command aucpl \"$@\"\n  fi\n}}"
-        );
-        return Ok(());
-    }
-
     let settings = get_settings()?;
     let project_root = get_project_root()?;
 

--- a/crates/cli/src/cli/cd.rs
+++ b/crates/cli/src/cli/cd.rs
@@ -26,9 +26,12 @@ pub fn exec(args: &ArgMatches) -> Result<()> {
     let project_root = get_project_root()?;
 
     let problems_dir = project_root.join(&settings.problems_dir);
-    if !fs::exists(&problems_dir).expect("Failed to check if path exists") {
-        fs::create_dir(&problems_dir).expect("Failed to create directory");
-    }
+    fs::create_dir_all(&problems_dir).with_context(|| {
+        format!(
+            "Failed to create problems directory at {}",
+            problems_dir.display()
+        )
+    })?;
 
     let target_path = match args.try_get_one::<String>("problem")? {
         Some(problem_name) => {

--- a/crates/cli/src/cli/cd.rs
+++ b/crates/cli/src/cli/cd.rs
@@ -1,0 +1,58 @@
+use std::fs;
+
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+
+use crate::config::get_settings;
+use crate::paths::resolve_stored_path;
+use crate::problem::sync_mappings::get_problem;
+use crate::util::get_project_root;
+
+pub fn cli() -> Command {
+    Command::new("cd")
+        .about("Print the target directory for a problem or the workspace root")
+        .arg(
+            Arg::new("shell-hook")
+                .long("shell-hook")
+                .help("Print shell integration snippet so 'aucpl cd' changes your current shell directory")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("problem")
+                .help("Problem name")
+                .action(ArgAction::Set),
+        )
+}
+
+pub fn exec(args: &ArgMatches) -> Result<()> {
+    if args.get_flag("shell-hook") {
+        println!(
+            "aucpl() {{\n  if [ \"$1\" = \"cd\" ]; then\n    shift\n    local target\n    target=\"$(command aucpl cd \"$@\")\" || return $?\n    builtin cd -- \"$target\"\n  else\n    command aucpl \"$@\"\n  fi\n}}"
+        );
+        return Ok(());
+    }
+
+    let settings = get_settings()?;
+    let project_root = get_project_root()?;
+
+    let problems_dir = project_root.join(&settings.problems_dir);
+    if !fs::exists(&problems_dir).expect("Failed to check if path exists") {
+        fs::create_dir(&problems_dir).expect("Failed to create directory");
+    }
+
+    let target_path = match args.try_get_one::<String>("problem")? {
+        Some(problem_name) => {
+            let relative_path = get_problem(&problems_dir, problem_name)?;
+            resolve_stored_path(&project_root, &relative_path)
+        }
+        None => problems_dir,
+    };
+
+    let target = target_path
+        .to_str()
+        .context("Target path contains invalid UTF-8")?;
+
+    println!("{target}");
+
+    Ok(())
+}

--- a/crates/cli/src/cli/cd.rs
+++ b/crates/cli/src/cli/cd.rs
@@ -10,8 +10,10 @@ use crate::util::get_project_root;
 
 pub fn cli() -> Command {
     Command::new("cd")
-        .about("Print the target directory for a problem or the workspace root.
-Evaluate `aucpl shellinit` to instead cd to the directory.")
+        .about(
+            "Print the target directory for a problem or the workspace root.
+Evaluate `aucpl shellinit` to instead cd to the directory.",
+        )
         .arg(
             Arg::new("problem")
                 .help("Problem name")

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -1,5 +1,6 @@
 use clap::Command;
 
+pub mod cd;
 pub mod comp;
 pub mod init;
 pub mod problem;
@@ -8,6 +9,7 @@ pub mod sync;
 
 pub fn builtin() -> Vec<Command> {
     vec![
+        cd::cli(),
         comp::cli(),
         init::cli(),
         problem::cli(),

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -5,6 +5,7 @@ pub mod comp;
 pub mod init;
 pub mod problem;
 pub mod publish;
+pub mod shellinit;
 pub mod sync;
 
 pub fn builtin() -> Vec<Command> {
@@ -14,6 +15,7 @@ pub fn builtin() -> Vec<Command> {
         init::cli(),
         problem::cli(),
         publish::cli(),
+        shellinit::cli(),
         sync::cli(),
     ]
 }

--- a/crates/cli/src/cli/shellinit.rs
+++ b/crates/cli/src/cli/shellinit.rs
@@ -9,18 +9,9 @@ pub fn cli() -> Command {
 pub fn exec(args: &ArgMatches) -> Result<()> {
     _ = args;
 
-        println!(
-                r#"aucpl() {
-    if [ "$1" = "cd" ]; then
-        shift
-        local target
-        target="$(command aucpl cd "$@")" || return $?
-        builtin cd -- "$target"
-    else
-        command aucpl "$@"
-    fi
-}"#
-        );
+    println!(
+        r#"aucpl() {{ if [ "$1" = "cd" ]; then shift; local target; target="$(command aucpl cd "$@")" || return $?; builtin cd -- "$target"; else command aucpl "$@"; fi; }}"#
+    );
 
     Ok(())
 }

--- a/crates/cli/src/cli/shellinit.rs
+++ b/crates/cli/src/cli/shellinit.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+use clap::{ArgMatches, Command};
+
+pub fn cli() -> Command {
+    Command::new("shellinit")
+        .about("Print shell initialization snippet for aucpl command integration")
+}
+
+pub fn exec(args: &ArgMatches) -> Result<()> {
+    _ = args;
+
+        println!(
+                r#"aucpl() {
+    if [ "$1" = "cd" ]; then
+        shift
+        local target
+        target="$(command aucpl cd "$@")" || return $?
+        builtin cd -- "$target"
+    else
+        command aucpl "$@"
+    fi
+}"#
+        );
+
+    Ok(())
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -93,6 +93,7 @@ fn run() -> Result<()> {
     set_verbose(matches.get_flag("verbose"));
 
     match matches.subcommand() {
+        Some(("cd", cmd)) => cli::cd::exec(cmd)?,
         Some(("comp", cmd)) => cli::comp::exec(cmd)?,
         Some(("init", cmd)) => cli::init::exec(cmd)?,
         Some(("problem", cmd)) => cli::problem::exec(cmd)?,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -98,6 +98,7 @@ fn run() -> Result<()> {
         Some(("init", cmd)) => cli::init::exec(cmd)?,
         Some(("problem", cmd)) => cli::problem::exec(cmd)?,
         Some(("publish", cmd)) => cli::publish::exec(cmd)?,
+        Some(("shellinit", cmd)) => cli::shellinit::exec(cmd)?,
         Some(("sync", cmd)) => cli::sync::exec(cmd)?,
         _ => unreachable!(),
     }


### PR DESCRIPTION
Added `aucpl cd`, allowing changing directory to problem directories, or the root directory if no argument is passed. However, by default this will just print the directory. You must run `eval $(aucpl shellinit)` first (or add it to your zshrc or bashrc) to enable the actual directory-changing behaviour. This is because the CLI executable can't change the working directory of the parent.